### PR TITLE
Search Bar Fix

### DIFF
--- a/data_catalogue.html
+++ b/data_catalogue.html
@@ -91,7 +91,7 @@
 						<div class="box-search">
 							<form action="https://ipcc.metadata.works/browser/search" class="searchbar-container">
 								<input name="search-term" autocomplete="off" placeholder="Search all datasets"
-									class="searchbar" type="text" value="" pattern="\S+.*" maxlength="50" required>
+									class="searchbar" type="text" value="" pattern="\S+.*" maxlength="100" size="50" required>
 								<button class="search-btn"> <img src="./assets/images/search-blue.svg" alt="MetadataWorks">SEARCH</button>
 							</form>
 						</div>
@@ -178,7 +178,6 @@
 		}
 
 		.searchbar {
-			width: 100%;
 			outline: none;
 		}
 


### PR DESCRIPTION
width: 100% was making the search bar too chunky (vertically), so using size="50" again...